### PR TITLE
zero_traces computed with spatial=False

### DIFF
--- a/seismiqb/src/geometry/segy.py
+++ b/seismiqb/src/geometry/segy.py
@@ -128,6 +128,14 @@ class SeismicGeometrySEGY(SeismicGeometry):
 
         self.cube_shape = np.asarray([*self.lens, self.depth])
 
+    def _get_store_key(self, traceseqno):
+        """ get trace lateral coordinates from header """
+        header = self.segyfile.header[traceseqno]
+        # i -> id in a dataframe
+        keys = [header.get(field) for field in self.byte_no]
+        store_key = tuple(self.uniques_inversed[j][item] for j, item in enumerate(keys))
+        return store_key
+
     def collect_stats(self, spatial=True, bins=25, num_keep=10000, pbar=True, **kwargs):
         """ Pass through file data to collect stats:
             - min/max values.
@@ -157,19 +165,27 @@ class SeismicGeometrySEGY(SeismicGeometry):
         # Get min/max values, store some of the traces
         trace_container = []
         value_min, value_max = np.inf, -np.inf
+        min_matrix, max_matrix = np.full(self.lens, np.nan), np.full(self.lens, np.nan)
 
         for i in tqdm(range(num_traces), desc='Finding min/max', ncols=800, disable=(not pbar)):
             trace = self.segyfile.trace[i]
+            store_key = self._get_store_key(i)
 
             trace_min, trace_max = find_min_max(trace)
-            if trace_min < value_min:
-                value_min = trace_min
-            if trace_max > value_max:
-                value_max = trace_max
+            min_matrix[store_key] = trace_min
+            max_matrix[store_key] = trace_max
 
             if i % frequency == 0 and trace_min != trace_max:
                 trace_container.extend(trace.tolist())
                 #TODO: add dtype for storing
+
+        # Store everything into instance
+        self.min_matrix, self.max_matrix = min_matrix, max_matrix
+        self.zero_traces = (min_matrix == max_matrix).astype(np.int)
+        self.zero_traces[np.isnan(min_matrix)] = 1
+
+        value_min = np.nanmin(min_matrix)
+        value_max = np.nanmax(max_matrix)
 
         # Collect more spatial stats: min, max, mean, std, histograms matrices
         if spatial:
@@ -178,25 +194,16 @@ class SeismicGeometrySEGY(SeismicGeometry):
             self.bins = bins
 
             # Create containers
-            min_matrix, max_matrix = np.full(self.lens, np.nan), np.full(self.lens, np.nan)
             hist_matrix = np.full((*self.lens, len(bins)-1), np.nan)
 
             # Iterate over traces
             description = f'Collecting stats for {self.name}'
             for i in tqdm(range(num_traces), desc=description, ncols=800, disable=(not pbar)):
                 trace = self.segyfile.trace[i]
-                header = self.segyfile.header[i]
-
-                # i -> id in a dataframe
-                keys = [header.get(field) for field in self.byte_no]
-                store_key = [self.uniques_inversed[j][item] for j, item in enumerate(keys)]
-                store_key = tuple(store_key)
+                store_key = self._get_store_key(i)
 
                 # For each trace, we store an entire histogram of amplitudes
                 val_min, val_max = find_min_max(trace)
-                min_matrix[store_key] = val_min
-                max_matrix[store_key] = val_max
-
                 if val_min != val_max:
                     histogram = np.histogram(trace, bins=bins)[0]
                     hist_matrix[store_key] = histogram
@@ -211,11 +218,8 @@ class SeismicGeometrySEGY(SeismicGeometry):
                                         axis=-1))
 
             # Store everything into instance
-            self.min_matrix, self.max_matrix = min_matrix, max_matrix
             self.mean_matrix, self.std_matrix = mean_matrix, std_matrix
             self.hist_matrix = hist_matrix
-            self.zero_traces = (min_matrix == max_matrix).astype(np.int)
-            self.zero_traces[np.isnan(min_matrix)] = 1
 
         self.trace_container = np.array(trace_container)
         self.v_uniques = len(np.unique(trace_container))
@@ -225,7 +229,6 @@ class SeismicGeometrySEGY(SeismicGeometry):
         self.v_q999, self.v_q99, self.v_q95 = np.quantile(trace_container, [0.999, 0.99, 0.95])
         self.has_stats = True
         self.store_meta()
-
 
     # Compute stats from CDP/LINES correspondence
     def compute_rotation_matrix(self):


### PR DESCRIPTION
computing zero_traces is moved out of `spatial` branch to reduce time for stats collection when histogram info is not needed

for a 881x691x1501 sgy cube time for creating a SeismicGeometry with stats collection has slightly increased:

||spatial=True|spatial=False|
|-|------------|---------------|
|old |77s| error, if meta not existed|
|new|79s|19s|

||1 stats collection pass| 2 pass|
|-|-|-|
|old| 8s | 62s|
|new| 14s|61s| 


optional further changes
* move 1 pass of stats collection to `not hasattr(self, 'zero_traces')` branch of `process`, because current method of approximate zero_traces calculation raises an error
* rename `spatial` parameter of `collect_stats` to `histograms` or a like
* change the default value of `collect_stats` parameter of `process` to True


