### PR TITLE
Add Accumulator3D

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,7 @@ disable=no-value-for-parameter, no-self-use, too-few-public-methods, unsubscript
         no-member, arguments-differ, len-as-condition, keyword-arg-before-vararg, too-many-locals, too-many-lines,
         logging-format-interpolation, no-name-in-module, import-error, cyclic-import, duplicate-code, import-self,
         abstract-method, relative-beyond-top-level, unused-argument, too-many-public-methods, too-many-instance-attributes,
-        invalid-name, consider-using-generator
+        invalid-name, consider-using-generator, attribute-defined-outside-init
 
 [TYPECHECK]
 ignored-modules=numpy, numba

--- a/seismiqb/src/crop_batch.py
+++ b/seismiqb/src/crop_batch.py
@@ -1249,20 +1249,21 @@ class SeismicCropBatch(Batch):
 
     @action
     @inbatch_parallel(init='indices', post=None, target='for')
-    def update_container(self, ix, src, container, src_locations='locations', order=(0, 1, 2)):
-        """ Aggregate crops to form resulting cube
+    def update_accumulator(self, ix, src, accumulator, src_locations='locations', order=(0, 1, 2)):
+        """ Update accumulator with data from crops.
+
         Parameters
         ----------
         src : str
-            Component with crops
-        container : BaseAggregationContainer
-            Container for resulting cube aggregation.
+            Component with crops.
+        accumulator : Accumulator3D
+            Container for cube aggregation.
         src_locations : src
-            Component with crop location, default: locations
-        order : tuple
+            Component with crop location.
+        order : sequence
             The order of axes of the crop which corresponds to natural iline-xline-depth order
         """
         crop = self.get(ix, src)
         location = self.get(ix, src_locations)
-        container.put(crop.transpose(order), location)
+        accumulator.update(crop.transpose(order), location)
         return self

--- a/seismiqb/src/geometry/array.py
+++ b/seismiqb/src/geometry/array.py
@@ -36,7 +36,7 @@ class DummyFile:
 
 class SeismicGeometryArray(SeismicGeometryHDF5):
     """ Numpy array stored in memory as a  SeismicGeometry"""
-    #pylint: disable=attribute-defined-outside-init
+    #pylint: disable=attribute-defined-outside-init, access-member-before-definition
     def process(self, dummyfile, num_keep=10000, **kwargs):
         self.array = dummyfile.data
 

--- a/seismiqb/src/geometry/array.py
+++ b/seismiqb/src/geometry/array.py
@@ -38,6 +38,7 @@ class SeismicGeometryArray(SeismicGeometryHDF5):
     """ Numpy array stored in memory as a  SeismicGeometry"""
     #pylint: disable=attribute-defined-outside-init, access-member-before-definition
     def process(self, dummyfile, num_keep=10000, **kwargs):
+        """ Store references to data array. """
         self.array = dummyfile.data
 
         self.available_axis = [0]

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -582,11 +582,19 @@ class SeismicGeometry(ExportMixin):
         msg = f"""
         Geometry for cube              {self.displayed_path}
         Current index:                 {self.index_headers}
-        Cube shape:                    {self.cube_shape}
+        Cube shape:                    {tuple(self.cube_shape)}
         Time delay:                    {self.delay}
         Sample rate:                   {self.sample_rate}
+        Area:                          {self.area:4.1f} km²
+        """
 
-        Cube size:                     {os.path.getsize(self.path) / (1024**3):4.3f} GB
+        if os.path.exists(self.segy_path):
+            segy_size = os.path.getsize(self.segy_path) / (1024 ** 3)
+            msg += f"""
+        SEG-Y original size:           {segy_size:4.3f} GB
+        """
+
+        msg += f"""Current cube size:             {self.file_size:4.3f} GB
         Size of the instance:          {self.ngbytes:4.3f} GB
 
         Number of traces:              {self.total_traces}
@@ -594,7 +602,8 @@ class SeismicGeometry(ExportMixin):
 
         if hasattr(self, 'zero_traces'):
             msg += f"""Number of non-zero traces:     {self.nonzero_traces}
-            """
+        Fullness:                      {self.nonzero_traces / self.total_traces:2.2f}
+        """
 
         if self.has_stats:
             msg += f"""

--- a/seismiqb/src/utility_classes.py
+++ b/seismiqb/src/utility_classes.py
@@ -1,4 +1,5 @@
 """ Helper classes. """
+import os
 from time import perf_counter
 from collections import OrderedDict, defaultdict
 from threading import RLock
@@ -14,6 +15,7 @@ except ImportError:
     cp = np
     CUPY_AVAILABLE = False
 from numba import njit
+import h5py
 
 from ..batchflow import Sampler
 
@@ -221,6 +223,232 @@ class Accumulator:
             value = self.indices
 
         return value
+
+
+
+class Accumulator3D:
+    """ Base class to aggregate predicted sub-volumes into a larger 3D cube.
+    Can accumulate data in memory (Numpy arrays) or on disk (HDF5 datasets).
+
+    Type of aggregation is defined in subclasses, that must implement `_init`, `_update` and `_aggregate` methods.
+
+    Supposed to be used in combination with `:meth:.~SeismicCubeset.make_grid` in a following manner:
+        - `make_grid` defines how to split desired cube range into small crops
+        - `Accumulator3D` creates necessary placeholders for a desired type of aggregation
+        - `update_accumulator` action of pipeline passes individual crops (and their locations) to
+        update those placeholders (see `:meth:~.update`)
+        - `:meth:~.aggregate` is used to get the resulting volume
+
+    This class is an alternative to `:meth:.~SeismicCubeset.assemble_crops`, but allows to
+    greatly reduce memory footprint of crop aggregation by up to `overlap_factor` times.
+    Also, as this class updates rely on `location`s of crops, it can take crops in any order.
+
+    Note that not all pixels of placeholders will be updated with data due to removal of dead traces,
+    so we have to be careful with initialization!
+
+    Parameters
+    ----------
+    shape : sequence
+        Shape of the placeholder.
+    origin : sequence
+        The upper left point of the volume: used to shift crop's locations.
+    dtype : np.dtype
+        Dtype of storage. Must be either integer or float.
+    transform : callable, optional
+        Additional function to call before storing the crop data.
+    path : str, optional
+        If provided, then we use HDF5 datasets instead of regular Numpy arrays, storing the data directly on disk.
+        After the initialization, we keep the file handle in `w-` mode during the update phase.
+        After aggregation, we re-open the file to automatically repack it in `r` mode.
+    kwargs : dict
+        Other parameters are passed to HDF5 dataset creation.
+    """
+    def __init__(self, shape=None, origin=None, dtype=np.float32, fill_value=None, transform=None, path=None, **kwargs):
+        # Dimensionality and location
+        self.shape = shape
+        self.origin = origin
+
+        # Properties of storages
+        self.dtype = dtype
+        min_value = np.finfo(dtype).min if 'float' in dtype.__name__ else np.iinfo(dtype)
+        self.fill_value = fill_value if fill_value is not None else min_value
+        self.transform = transform if transform is not None else lambda array: array
+
+        # Container definition
+        if path is not None:
+            if os.path.exists(path):
+                os.remove(path)
+            self.path = path
+
+            self.file = h5py.File(path, mode='w-')
+            self.options = {**kwargs}
+        self.type = 'hdf5' if path is not None else 'numpy'
+
+        self.names = []
+        self.aggregated = False
+
+        # Create underlying storages
+        self._init()
+
+    def _init(self):
+        """ Initialize placeholders. """
+        raise NotImplementedError
+
+    def create_placeholder(self, name=None, dtype=None, fill_value=None):
+        """ Create named storage as a dataset of HDF5 or plain array. """
+        if self.type == 'hdf5':
+            options = {'fillvalue': fill_value, **self.options}
+            placeholder = self.file.create_dataset(name, shape=self.shape, dtype=dtype, **options)
+        elif self.type == 'numpy':
+            placeholder = np.full(shape=self.shape, fill_value=fill_value, dtype=dtype)
+
+        if name != 'data':
+            self.names.append(name)
+        return placeholder
+
+    def update(self, crop, location):
+        """ Update underlying storages in supplied `location` with data from `crop`. """
+        if self.aggregated:
+            raise RuntimeError('Aggregated data has been already computed!')
+
+        # Check all shapes for compatibility
+        for s, slc in zip(crop.shape, location):
+            if slc.step and slc.step != 1:
+                raise ValueError(f"Invalid step in location {location}")
+
+            if s < slc.stop - slc.start:
+                raise ValueError(f"Inconsistent crop_shape {crop.shape} and location {location}")
+
+        # Compute correct shapes
+        loc, loc_crop = [], []
+        for xmin, slc, xmax in zip(self.origin, location, self.shape):
+            loc.append(slice(max(0, slc.start - xmin), min(xmax, slc.stop - xmin)))
+            loc_crop.append(slice(max(0, xmin - slc.start), min(xmax + xmin - slc.start , slc.stop - slc.start)))
+
+        # Actual update
+        crop = self.transform(crop[tuple(loc_crop)])
+        location = tuple(loc)
+        self._update(crop, location)
+
+    def _update(self, crop, location):
+        """ Update placeholders with data from `crop` at `locations`. """
+        _ = crop, location
+        raise NotImplementedError
+
+    def aggregate(self):
+        """ Finalize underlying storages to create required aggregation. """
+        if self.aggregated:
+            raise RuntimeError('All data in the container has already been cleared!')
+        self._aggregate()
+
+        # Cleanup
+        for name in self.names:
+            setattr(self, name, None)
+            if self.type == 'hdf5':
+                del self.file[name]
+
+        # Re-open the HDF5 file to optionally repack it
+        if self.type == 'hdf5':
+            self.file.close()
+            self.file = h5py.File(self.path, 'r')
+            self.data = self.file['data']
+
+        self.aggregated = True
+        return self.data
+
+    def _aggregate(self):
+        """ Aggregate placeholders into resulting array. Changes `data` placeholder inplace. """
+        raise NotImplementedError
+
+    def __del__(self):
+        if self.type == 'hdf5':
+            self.file.close()
+
+    @property
+    def result(self):
+        """ Reference to the aggregated result. """
+        if not self.aggregated:
+            self.aggregate()
+        return self.data
+
+    @classmethod
+    def from_aggregation(cls, aggregation='max', shape=None, origin=None, dtype=np.float32, fill_value=None,
+                         transform=None, path=None, **kwargs):
+        """ Initialize chosen type of accumulator aggregation. """
+        class_to_aggregation = {
+            MaxAccumulator3D: ['max', 'maximum'],
+            MeanAccumulator3D: ['mean', 'avg', 'average'],
+            GMeanAccumulator3D: ['gmean', 'geometric'],
+        }
+        aggregation_to_class = {alias: class_ for class_, lst in class_to_aggregation.items()
+                                for alias in lst}
+
+        return aggregation_to_class[aggregation](shape=shape, origin=origin, dtype=dtype, fill_value=fill_value,
+                                                 transform=transform, path=path, **kwargs)
+
+
+class MaxAccumulator3D(Accumulator3D):
+    """ Accumulator that takes maximum value of overlapping crops. """
+    def _init(self):
+        self.data = self.create_placeholder(name='data', dtype=self.dtype, fill_value=self.fill_value)
+
+    def _update(self, crop, location):
+        self.data[location] = np.maximum(crop, self.data[location])
+
+    def _aggregate(self):
+        pass
+
+
+class MeanAccumulator3D(Accumulator3D):
+    """ Accumulator that takes mean value of overlapping crops. """
+    def _init(self):
+        self.data = self.create_placeholder(name='data', dtype=self.dtype, fill_value=0)
+        self.counts = self.create_placeholder(name='counts', dtype=np.int8, fill_value=0)
+
+    def _update(self, crop, location):
+        self.data[location] += crop
+        self.counts[location] += 1
+
+    def _aggregate(self):
+        if self.type == 'hdf5':
+            # Amortized updates for HDF5
+            for i in range(self.data.shape[0]):
+                counts = self.counts[i]
+                counts[counts == 0] = 1
+                if 'float' in self.dtype.__name__:
+                    self.data[i] /= counts
+                else:
+                    self.data[i] //= counts
+
+        elif self.type == 'numpy':
+            self.counts[self.counts == 0] = 1
+            if 'float' in self.dtype.__name__:
+                self.data /= self.counts
+            else:
+                self.data //= self.counts
+
+
+class GMeanAccumulator3D(Accumulator3D):
+    """ Accumulator that takes geometric mean value of overlapping crops. """
+    def _init(self):
+        self.data = self.create_placeholder(name='data', dtype=self.dtype, fill_value=0)
+        self.counts = self.create_placeholder(name='counts', dtype=np.int8, fill_value=0)
+
+    def _update(self, crop, location):
+        self.data[location] += crop
+        self.counts[location] += 1
+
+    def _aggregate(self):
+        if self.type == 'hdf5':
+            # Amortized updates for HDF5
+            for i in range(self.data.shape[0]):
+                counts = self.counts[i]
+                counts[counts == 0] = 1
+                self.data[i] = np.pow(self.data[i], 1/counts)
+
+        elif self.type == 'numpy':
+            self.counts[self.counts == 0] = 1
+            self.data = np.pow(self.data, 1/self.counts)
 
 
 
@@ -475,129 +703,3 @@ class SafeIO:
 
         if self.log_file:
             self._info(self.log_file, f'Closed {self.path}')
-
-class BaseAggregationContainer:
-    """ Container for on-line aggregation of crops """
-
-    def __init__(self, shape=None, grid_range=None):
-        """ initialize inner storages
-
-        Parameters
-        ----------
-        shape : tuple or None
-            shape of the processed cube - if it is fully covered
-        grid_range: list of tuples
-            ilines, xlines, heights as in `~.SeismcCubeset.grid_info['range']`
-        """
-
-        if shape is not None:
-            self.shape = np.asarray(shape, dtype=np.int16)
-            self.origin = np.zeros_like(self.shape)
-        elif grid_range is not None:
-            grid_range = np.asarray(grid_range, dtype=np.int16)
-            self.origin = grid_range[:, 0]
-            self.shape = grid_range[:, 1] - self.origin
-        else:
-            raise ValueError('Either shape, or grid_range should be provided')
-
-        self.res = None
-        self.valid = True
-
-    def put(self, crop, location):
-        """ add crop for aggregation
-
-        Parameters
-        ----------
-        crop : np.ndarray
-            single crop
-        location : tuple of slices
-            coordinates of crop
-        """
-        if self.res is not None:
-            raise RuntimeError('Aggregated data has been already computed!')
-
-        if not self.valid:
-            raise RuntimeError('All data in the container has already been cleared!')
-
-        for crop_x, slc in zip(crop.shape, location):
-            if slc.step and slc.step != 1:
-                raise ValueError(f"Invalid step in location {location}")
-
-            beg, end, _ = slc.indices(slc.stop)
-            if crop_x < end - beg:
-                raise ValueError(f"Inconsistent crop_shape {crop.shape} and location {location}")
-
-        loc = tuple(slice(max(0, slc.start - x0), min(xlen, slc.stop - x0))
-               for x0, slc, xlen in zip(self.origin, location, self.shape))
-        loc_crop = tuple(slice(max(0, x0 - slc.start), min(xlen + x0 - slc.start , slc.stop - slc.start))
-                    for x0, slc, xlen in zip(self.origin, location, self.shape))
-
-        self._put(crop[loc_crop], loc)
-
-    def _put(self, crop, location):
-        raise NotImplementedError
-
-    def aggregate(self):
-        """ Computes and returns aggregated cube.
-        Data updates are not possible after calling `aggregate` """
-
-        if not self.valid:
-            raise RuntimeError('All data in the container has already been cleared!')
-
-        if self.res is None:
-            self.res = self._aggregate()
-            self._clear()
-        return self.res
-
-    def _aggregate(self):
-        raise NotImplementedError
-
-    def clear(self):
-        """ Clears all data """
-        self.valid = False
-        if self.res is not None:
-            self.res = None
-        self._clear()
-
-    def _clear(self):
-        """ clear data for aggregation process """
-        raise NotImplementedError
-
-
-class AvgContainer(BaseAggregationContainer):
-    """ Average aggregation of crops """
-
-    def __init__(self, shape=None, grid_range=None, dtype=np.float32):
-        super().__init__(shape, grid_range)
-        self.data = np.zeros(self.shape, dtype=dtype)
-        self.counts = np.zeros(self.shape, dtype=np.int8)
-
-    def _put(self, crop, location):
-        self.data[location] += crop
-        self.counts[location] += 1
-
-    def _aggregate(self):
-        self.counts[self.counts == 0] = 1
-        self.data /= self.counts
-        return self.data
-
-    def _clear(self):
-        self.counts = None
-        self.data = None
-
-
-class MaxContainer(BaseAggregationContainer):
-    """ Maximum aggregation of crops """
-
-    def __init__(self, shape=None, grid_range=None, fill_value=-np.inf, dtype=np.float32):
-        super().__init__(shape, grid_range)
-        self.data = np.full(self.shape, fill_value, dtype=dtype)
-
-    def _put(self, crop, location):
-        self.data[location] = np.maximum(self.data[location], crop)
-
-    def _aggregate(self):
-        return self.data
-
-    def _clear(self):
-        self.data = None

--- a/seismiqb/src/utility_classes.py
+++ b/seismiqb/src/utility_classes.py
@@ -364,6 +364,10 @@ class Accumulator3D:
         if self.type == 'hdf5':
             self.file.close()
 
+    def clear(self):
+        """ Remove references to placeholders. """
+        self.data = None
+
     @property
     def result(self):
         """ Reference to the aggregated result. """

--- a/seismiqb/src/utility_classes.py
+++ b/seismiqb/src/utility_classes.py
@@ -458,6 +458,8 @@ class GMeanAccumulator3D(Accumulator3D):
 
         elif self.type == 'numpy':
             self.counts[self.counts == 0] = 1
+
+            self.counts = self.counts.astype(np.float32)
             self.counts **= -1
             self.data **= self.counts
 

--- a/seismiqb/src/utility_classes.py
+++ b/seismiqb/src/utility_classes.py
@@ -270,7 +270,7 @@ class Accumulator3D:
 
         # Properties of storages
         self.dtype = dtype
-        min_value = np.finfo(dtype).min if 'float' in dtype.__name__ else np.iinfo(dtype)
+        min_value = np.finfo(dtype).min if 'float' in dtype.__name__ else np.iinfo(dtype).min
         self.fill_value = fill_value if fill_value is not None else min_value
         self.transform = transform if transform is not None else lambda array: array
 
@@ -304,7 +304,7 @@ class Accumulator3D:
 
         if name != 'data':
             self.names.append(name)
-        return placeholder
+        setattr(self, name, placeholder)
 
     def update(self, crop, location):
         """ Update underlying storages in supplied `location` with data from `crop`. """
@@ -397,7 +397,7 @@ class Accumulator3D:
 class MaxAccumulator3D(Accumulator3D):
     """ Accumulator that takes maximum value of overlapping crops. """
     def _init(self):
-        self.data = self.create_placeholder(name='data', dtype=self.dtype, fill_value=self.fill_value)
+        self.create_placeholder(name='data', dtype=self.dtype, fill_value=self.fill_value)
 
     def _update(self, crop, location):
         self.data[location] = np.maximum(crop, self.data[location])
@@ -409,8 +409,8 @@ class MaxAccumulator3D(Accumulator3D):
 class MeanAccumulator3D(Accumulator3D):
     """ Accumulator that takes mean value of overlapping crops. """
     def _init(self):
-        self.data = self.create_placeholder(name='data', dtype=self.dtype, fill_value=0)
-        self.counts = self.create_placeholder(name='counts', dtype=np.int8, fill_value=0)
+        self.create_placeholder(name='data', dtype=self.dtype, fill_value=0)
+        self.create_placeholder(name='counts', dtype=np.int8, fill_value=0)
 
     def _update(self, crop, location):
         self.data[location] += crop
@@ -438,8 +438,8 @@ class MeanAccumulator3D(Accumulator3D):
 class GMeanAccumulator3D(Accumulator3D):
     """ Accumulator that takes geometric mean value of overlapping crops. """
     def _init(self):
-        self.data = self.create_placeholder(name='data', dtype=self.dtype, fill_value=0)
-        self.counts = self.create_placeholder(name='counts', dtype=np.int8, fill_value=0)
+        self.create_placeholder(name='data', dtype=self.dtype, fill_value=0)
+        self.create_placeholder(name='counts', dtype=np.int8, fill_value=0)
 
     def _update(self, crop, location):
         self.data[location] *= crop

--- a/seismiqb/src/utility_classes.py
+++ b/seismiqb/src/utility_classes.py
@@ -368,6 +368,9 @@ class Accumulator3D:
         """ Remove references to placeholders. """
         self.data = None
 
+        if self.type == 'hdf5':
+            os.remove(self.path)
+
     @property
     def result(self):
         """ Reference to the aggregated result. """
@@ -439,7 +442,7 @@ class GMeanAccumulator3D(Accumulator3D):
         self.counts = self.create_placeholder(name='counts', dtype=np.int8, fill_value=0)
 
     def _update(self, crop, location):
-        self.data[location] += crop
+        self.data[location] *= crop
         self.counts[location] += 1
 
     def _aggregate(self):

--- a/seismiqb/src/utility_classes.py
+++ b/seismiqb/src/utility_classes.py
@@ -267,6 +267,9 @@ class Accumulator3D:
         Other parameters are passed to HDF5 dataset creation.
     """
     def __init__(self, shape=None, origin=None, dtype=np.float32, transform=None, path=None, **kwargs):
+        # Main attribute to store results
+        self.data = None
+
         # Dimensionality and location
         self.shape = shape
         self.origin = origin
@@ -339,7 +342,7 @@ class Accumulator3D:
             raise RuntimeError('All data in the container has already been cleared!')
         self._aggregate()
 
-        # Re-open the HDF5 file to optionally repack it
+        # Re-open the HDF5 file to force flush changes and release disk space from deleted datasets
         if self.type == 'hdf5':
             self.file.close()
             self.file = h5py.File(self.path, 'r')


### PR DESCRIPTION
This PR improves on @a-arefina work by allowing us to accumulate predicted crops either in memory or on disk, while also adding more aggregations and QoL changes to placeholder creation.

I will also include the following changes as soon as possible:

- [x] change `HorizonController` to use new accumulate logic
- [ ] add non-zero `prefetch` value for inference of `HorizonController`
- [x] correct `SeismicCubeset.show_slices` with `mask_rebatch`
- [x] augment `SeismicGeometry` repr with the size of original `SEG-Y` cube and area of the processed field