### PR TITLE
Stabilize show slide behavior

### DIFF
--- a/seismiqb/src/cubeset.py
+++ b/seismiqb/src/cubeset.py
@@ -443,7 +443,6 @@ class SeismicCubeset(Dataset):
             'xlabel': xlabel,
             'ylabel': ylabel,
             'extent': (xmin, xmax, ymin, ymax),
-            'transparize_masks': True,
             'legend': False, # TODO: Make every horizon mask creation individual to allow their distinction while plot.
             **kwargs
         }

--- a/seismiqb/src/cubeset.py
+++ b/seismiqb/src/cubeset.py
@@ -367,8 +367,7 @@ class SeismicCubeset(Dataset):
                                                                 printer=printer, hist=hist, plot=plot)
 
 
-    def show_slide(self, loc, idx=0, axis='iline', zoom_slice=None,
-                   n_ticks=5, delta_ticks=100, src_labels='labels', **kwargs):
+    def show_slide(self, loc, idx=0, axis='iline', zoom_slice=None, src_labels='labels', **kwargs):
         """ Show full slide of the given cube on the given line.
 
         Parameters
@@ -410,7 +409,7 @@ class SeismicCubeset(Dataset):
 
         if 'masks' in components:
             use_labels = kwargs.pop('use_labels', 'all')
-            width = kwargs.pop('width', 5)
+            width = kwargs.pop('width', crop_shape[-1] // 100)
             labels_pipeline = (Pipeline()
                                .create_masks(src_labels=src_labels, dst='masks', width=width, use_labels=use_labels))
 
@@ -418,13 +417,14 @@ class SeismicCubeset(Dataset):
 
         batch = (pipeline << self).next_batch(len(self), n_epochs=None)
         imgs = [np.squeeze(getattr(batch, comp)) for comp in components]
-        xticks = list(range(imgs[0].shape[0]))
-        yticks = list(range(imgs[0].shape[1]))
+        xmin, xmax, ymin, ymax = 0, imgs[0].shape[0], imgs[0].shape[1], 0
 
         if zoom_slice:
             imgs = [img[zoom_slice] for img in imgs]
-            xticks = xticks[zoom_slice[0]]
-            yticks = yticks[zoom_slice[1]]
+            xmin = zoom_slice[0].start or xmin
+            xmax = zoom_slice[0].stop or xmax
+            ymin = zoom_slice[1].stop or xmin
+            ymax = zoom_slice[1].start or xmax
 
         # Plotting defaults
         header = geometry.axis_names[axis]
@@ -437,23 +437,13 @@ class SeismicCubeset(Dataset):
             xlabel = geometry.index_headers[0]
             ylabel = geometry.index_headers[1]
 
-        xticks = xticks[::max(1, round(len(xticks) // (n_ticks - 1) / delta_ticks)) * delta_ticks] + [xticks[-1]]
-        xticks = sorted(list(set(xticks)))
-        yticks = yticks[::max(1, round(len(xticks) // (n_ticks - 1) / delta_ticks)) * delta_ticks] + [yticks[-1]]
-        yticks = sorted(list(set(yticks)), reverse=True)
-
-        if len(xticks) > 2 and (xticks[-1] - xticks[-2]) < delta_ticks:
-            xticks.pop(-2)
-        if len(yticks) > 2 and (yticks[0] - yticks[1]) < delta_ticks:
-            yticks.pop(1)
-
         kwargs = {
             'title_label': f'Data slice on cube `{geometry.displayed_name}`\n {header} {loc} out of {total}',
             'title_y': 1.01,
             'xlabel': xlabel,
             'ylabel': ylabel,
-            'xticks': tuple(xticks),
-            'yticks': tuple(yticks),
+            'extent': (xmin, xmax, ymin, ymax),
+            'transparize_masks': True,
             'legend': False, # TODO: Make every horizon mask creation individual to allow their distinction while plot.
             **kwargs
         }

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -677,8 +677,7 @@ class SeismicGeometry(ExportMixin):
         }
         return plot_image(data, backend='matplotlib', bins=bins, mode='histogram', **kwargs)
 
-    def show_slide(self, loc=None, start=None, end=None, step=1, axis=0, zoom_slice=None,
-                   n_ticks=5, delta_ticks=100, stable=True, **kwargs):
+    def show_slide(self, loc=None, start=None, end=None, step=1, axis=0, zoom_slice=None, stable=True, **kwargs):
         """ Show seismic slide in desired place.
         Under the hood relies on :meth:`load_slide`, so works with geometries in any formats.
 

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -697,13 +697,14 @@ class SeismicGeometry(ExportMixin):
         """
         axis = self.parse_axis(axis)
         slide = self.load_slide(loc=loc, start=start, end=end, step=step, axis=axis, stable=stable)
-        xticks = list(range(slide.shape[0]))
-        yticks = list(range(slide.shape[1]))
+        xmin, xmax, ymin, ymax = 0, slide.shape[0], slide.shape[1], 0
 
         if zoom_slice:
             slide = slide[zoom_slice]
-            xticks = xticks[zoom_slice[0]]
-            yticks = yticks[zoom_slice[1]]
+            xmin = zoom_slice[0].start or xmin
+            xmax = zoom_slice[0].stop or xmax
+            ymin = zoom_slice[1].stop or xmin
+            ymax = zoom_slice[1].start or xmax
 
         # Plot params
         if len(self.index_headers) > 1:
@@ -720,23 +721,12 @@ class SeismicGeometry(ExportMixin):
             xlabel = self.index_headers[0]
             ylabel = 'DEPTH'
 
-        xticks = xticks[::max(1, round(len(xticks) // (n_ticks - 1) / delta_ticks)) * delta_ticks] + [xticks[-1]]
-        xticks = sorted(list(set(xticks)))
-        yticks = yticks[::max(1, round(len(xticks) // (n_ticks - 1) / delta_ticks)) * delta_ticks] + [yticks[-1]]
-        yticks = sorted(list(set(yticks)), reverse=True)
-
-        if len(xticks) > 2 and (xticks[-1] - xticks[-2]) < delta_ticks:
-            xticks.pop(-2)
-        if len(yticks) > 2 and (yticks[0] - yticks[1]) < delta_ticks:
-            yticks.pop(1)
-
         kwargs = {
             'title': title,
             'xlabel': xlabel,
             'ylabel': ylabel,
             'cmap': 'gray',
-            'xticks': tuple(xticks),
-            'yticks': tuple(yticks),
+            'extent': (xmin, xmax, ymin, ymax),
             'labeltop': False,
             'labelright': False,
             **kwargs

--- a/seismiqb/src/horizon.py
+++ b/seismiqb/src/horizon.py
@@ -2273,7 +2273,7 @@ class Horizon:
                                      matrix=self.full_matrix, threshold=threshold)
         return x, y, z, simplices
 
-    def show_slide(self, loc, width=None, axis='i', zoom_slice=None, n_ticks=5, delta_ticks=100, **kwargs):
+    def show_slide(self, loc, width=None, axis='i', zoom_slice=None, **kwargs):
         """ Show slide with horizon on it.
 
         Parameters
@@ -2336,10 +2336,8 @@ class Horizon:
             'curve_width': width,
             'grid': [False, True],
             'colorbar': [True, False],
-            'transparize_masks': True,
             **kwargs
         }
-
         return plot_image(data=[seismic_slide, mask], **kwargs)
 
 

--- a/seismiqb/src/horizon.py
+++ b/seismiqb/src/horizon.py
@@ -2294,19 +2294,20 @@ class Horizon:
 
         # Load seismic and mask
         seismic_slide = self.geometry.load_slide(loc=loc, axis=axis)
+        xmin, xmax, ymin, ymax = 0, seismic_slide.shape[0], seismic_slide.shape[1], 0
 
         mask = np.zeros(shape)
         width = width or seismic_slide.shape[1] // 100
         mask = self.add_to_mask(mask, locations=locations, width=width)
         seismic_slide, mask = np.squeeze(seismic_slide), np.squeeze(mask)
-        xticks = list(range(seismic_slide.shape[0]))
-        yticks = list(range(seismic_slide.shape[1]))
 
         if zoom_slice:
             seismic_slide = seismic_slide[zoom_slice]
             mask = mask[zoom_slice]
-            xticks = xticks[zoom_slice[0]]
-            yticks = yticks[zoom_slice[1]]
+            xmin = zoom_slice[0].start or xmin
+            xmax = zoom_slice[0].stop or xmax
+            ymin = zoom_slice[1].stop or xmin
+            ymax = zoom_slice[1].start or xmax
 
         # defaults for plotting if not supplied in kwargs
         header = self.geometry.axis_names[axis]
@@ -2320,16 +2321,6 @@ class Horizon:
             ylabel = self.geometry.index_headers[1]
             total = self.geometry.depth
 
-        xticks = xticks[::max(1, round(len(xticks) // (n_ticks - 1) / delta_ticks)) * delta_ticks] + [xticks[-1]]
-        xticks = sorted(list(set(xticks)))
-        yticks = yticks[::max(1, round(len(xticks) // (n_ticks - 1) / delta_ticks)) * delta_ticks] + [yticks[-1]]
-        yticks = sorted(list(set(yticks)), reverse=True)
-
-        if len(xticks) > 2 and (xticks[-1] - xticks[-2]) < delta_ticks:
-            xticks.pop(-2)
-        if len(yticks) > 2 and (yticks[0] - yticks[1]) < delta_ticks:
-            yticks.pop(1)
-
         title = f'Horizon `{self.name}` on cube `{self.geometry.displayed_name}`\n {header} {loc} out of {total}'
 
         kwargs = {
@@ -2338,15 +2329,14 @@ class Horizon:
             'title_y': 1.02,
             'xlabel': xlabel,
             'ylabel': ylabel,
-            'xticks': tuple(xticks),
-            'yticks': tuple(yticks),
-            'extent': (xticks[0], xticks[-1], yticks[0], yticks[-1]),
+            'extent': (xmin, xmax, ymin, ymax),
             'legend': False,
             'labeltop': False,
             'labelright': False,
             'curve_width': width,
             'grid': [False, True],
             'colorbar': [True, False],
+            'transparize_masks': True,
             **kwargs
         }
 

--- a/seismiqb/src/plotters.py
+++ b/seismiqb/src/plotters.py
@@ -406,9 +406,11 @@ class MatplotlibPlotter:
                 Order of image axes.
             bad_values : list of numbers
                 Data values that should be displayed with 'bad_color'.
-            transparize_masks : bool
+            transparize_masks : bool, optional
                 Whether treat zeros in binary masks as bad values or not.
-                If True, makes zero values in binary masks transparent on display.
+                If True, make zero values in all binary masks transparent on display.
+                If False, do not make zero values in any binary masks transparent on display.
+                If not provided, make zero values transparent in all masks that overlay an image.
             params for images drawn by `plt.imshow`:
                 - 'cmap', 'vmin', 'vmax', 'interpolation', 'alpha', 'extent'
                 - params with 'imshow_' prefix


### PR DESCRIPTION
1. Stop using `xticks` and `yticks` in favor of `extent`
   to display labels ticks correctly when `zoom_slice` is not None.
2. Add `transparize_masks` flag to 'imshow' mode of `plot_image`
   to control 'detect binary mask' behaviour. Also add additional
   check, if given array is a binary mask with zeros only.