### PR TITLE
Add grid extension and filter_outliers in quality_grid

### DIFF
--- a/seismiqb/src/functional.py
+++ b/seismiqb/src/functional.py
@@ -362,7 +362,7 @@ def extend_grid(grid, idx_1, idx_2, max_idx_2, transposed, extension, max_freque
 
     return grid
 
-def gridify(matrix, frequencies, iline=True, xline=True, extension='full', filter_outliers=0):
+def gridify(matrix, frequencies, iline=True, xline=True, extension='cell', filter_outliers=0):
     """ Convert digitized map into grid with various frequencies corresponding to different bins.
 
     Parameters

--- a/seismiqb/src/functional.py
+++ b/seismiqb/src/functional.py
@@ -374,12 +374,13 @@ def gridify(matrix, frequencies, iline=True, xline=True, extension='full', filte
     extension : 'full', 'cell', False or int
         Number of traces to grid lines extension.
         If 'full', then extends quality grid base points to field borders.
-        If 'cell', then extends quality grid base points to sparce grid cells borders.
+        If 'cell', then extends quality grid base points to sparse grid cells borders.
         If False, then make no extension.
         If int, then extends quality grid base points to +-extension//2 neighboring points.
     filter_outliers : int
-        A degree of quality map decimation.
-        `filter_outliers` more than zero cuts small complex areas.
+        A degree of quality map thinning.
+        `filter_outliers` more than zero cuts areas that contain too small connectivity regions.
+        Notice that the method cut the squared area with these regions. It is made for more thinning.
     """
     # Preprocess a matrix: drop small complex regions from a quality map to make grid thinned
     if filter_outliers > 0:

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -473,7 +473,10 @@ class SeismicGeometry(CacheMixin, ExportMixin):
             self.make_quality_grid()
         return self._quality_grid
 
-    def make_quality_grid(self, frequencies=(100, 200), iline=True, xline=True, full_lines=True, margin=0, **kwargs):
+    def make_quality_grid(
+        self, frequencies=(100, 200), iline=True, xline=True, full_lines=True,
+        margin=0, elongation=0, filter_outliers=0, **kwargs
+    ):
         """ Create `quality_grid` based on `quality_map`.
 
         Parameters
@@ -486,13 +489,19 @@ class SeismicGeometry(CacheMixin, ExportMixin):
             Whether to make lines on the whole spatial range.
         margin : int
             Margin of boundaries to not include in the grid.
+        elongation : int
+            Number of traces to grid lines elongation.
+        filter_outliers : int
+            A degree of quality map decimation.
+            `filter_outliers` more than zero cuts small complex areas.
         kwargs : dict
             Other parameters of grid making.
         """
         from ..metrics import GeometryMetrics #pylint: disable=import-outside-toplevel
         quality_grid = GeometryMetrics(self).make_grid(self.quality_map, frequencies,
                                                        iline=iline, xline=xline, full_lines=full_lines,
-                                                       margin=margin, **kwargs)
+                                                       margin=margin, elongation=elongation,
+                                                       filter_outliers=filter_outliers, **kwargs)
         self._quality_grid = quality_grid
         return quality_grid
 

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -473,8 +473,8 @@ class SeismicGeometry(CacheMixin, ExportMixin):
             self.make_quality_grid()
         return self._quality_grid
 
-    def make_quality_grid(self, frequencies=(100, 200), iline=True, xline=True, full_lines=True,
-                          margin=0, elongation=0, filter_outliers=0, **kwargs):
+    def make_quality_grid(self, frequencies=(100, 200), iline=True, xline=True, margin=0,
+                          elongation='full_lines', filter_outliers=0, **kwargs):
         """ Create `quality_grid` based on `quality_map`.
 
         Parameters
@@ -483,8 +483,6 @@ class SeismicGeometry(CacheMixin, ExportMixin):
             Grid frequencies for individual levels of hardness in `quality_map`.
         iline, xline : bool
             Whether to make lines in grid to account for `ilines`/`xlines`.
-        full_lines : bool
-            Whether to make lines on the whole spatial range.
         margin : int
             Margin of boundaries to not include in the grid.
         elongation : int
@@ -496,10 +494,11 @@ class SeismicGeometry(CacheMixin, ExportMixin):
             Other parameters of grid making.
         """
         from ..metrics import GeometryMetrics #pylint: disable=import-outside-toplevel
-        quality_grid = GeometryMetrics(self).make_grid(self.quality_map, frequencies,
-                                                       iline=iline, xline=xline, full_lines=full_lines,
-                                                       margin=margin, elongation=elongation,
-                                                       filter_outliers=filter_outliers, **kwargs)
+
+        elongation = kwargs.pop('full_lines', elongation) # for old api consistency
+        quality_grid = GeometryMetrics(self).make_grid(self.quality_map, frequencies, iline=iline, xline=xline,
+                                                       margin=margin, elongation=elongation, filter_outliers=filter_outliers,
+                                                       **kwargs)
         self._quality_grid = quality_grid
         return quality_grid
 

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -473,10 +473,8 @@ class SeismicGeometry(CacheMixin, ExportMixin):
             self.make_quality_grid()
         return self._quality_grid
 
-    def make_quality_grid(
-        self, frequencies=(100, 200), iline=True, xline=True, full_lines=True,
-        margin=0, elongation=0, filter_outliers=0, **kwargs
-    ):
+    def make_quality_grid(self, frequencies=(100, 200), iline=True, xline=True, full_lines=True,
+                          margin=0, elongation=0, filter_outliers=0, **kwargs):
         """ Create `quality_grid` based on `quality_map`.
 
         Parameters

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -474,7 +474,7 @@ class SeismicGeometry(CacheMixin, ExportMixin):
         return self._quality_grid
 
     def make_quality_grid(self, frequencies=(100, 200), iline=True, xline=True, margin=0,
-                          extension='full', filter_outliers=0, **kwargs):
+                          extension='cell', filter_outliers=0, **kwargs):
         """ Create `quality_grid` based on `quality_map`.
 
         Parameters

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -488,12 +488,13 @@ class SeismicGeometry(CacheMixin, ExportMixin):
         extension : 'full', 'cell', False or int
             Number of traces to grid lines extension.
             If 'full', then extends quality grid base points to field borders.
-            If 'cell', then extends quality grid base points to sparce grid cells borders.
+            If 'cell', then extends quality grid base points to sparse grid cells borders.
             If False, then make no extension.
             If int, then extends quality grid base points to +-extension//2 neighboring points.
         filter_outliers : int
-            A degree of quality map decimation.
-            `filter_outliers` more than zero cuts small complex areas.
+            A degree of quality map thinning.
+            `filter_outliers` more than zero cuts areas that contain too small connectivity regions.
+            Notice that the method cut the squared area with these regions. It is made for more thinning.
         kwargs : dict
             Other parameters of grid making.
         """

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -497,8 +497,8 @@ class SeismicGeometry(CacheMixin, ExportMixin):
 
         elongation = kwargs.pop('full_lines', elongation) # for old api consistency
         quality_grid = GeometryMetrics(self).make_grid(self.quality_map, frequencies, iline=iline, xline=xline,
-                                                       margin=margin, elongation=elongation, filter_outliers=filter_outliers,
-                                                       **kwargs)
+                                                       margin=margin, elongation=elongation,
+                                                       filter_outliers=filter_outliers, **kwargs)
         self._quality_grid = quality_grid
         return quality_grid
 

--- a/seismiqb/src/geometry/base.py
+++ b/seismiqb/src/geometry/base.py
@@ -474,7 +474,7 @@ class SeismicGeometry(CacheMixin, ExportMixin):
         return self._quality_grid
 
     def make_quality_grid(self, frequencies=(100, 200), iline=True, xline=True, margin=0,
-                          elongation='full_lines', filter_outliers=0, **kwargs):
+                          extension='full', filter_outliers=0, **kwargs):
         """ Create `quality_grid` based on `quality_map`.
 
         Parameters
@@ -485,8 +485,12 @@ class SeismicGeometry(CacheMixin, ExportMixin):
             Whether to make lines in grid to account for `ilines`/`xlines`.
         margin : int
             Margin of boundaries to not include in the grid.
-        elongation : int
-            Number of traces to grid lines elongation.
+        extension : 'full', 'cell', False or int
+            Number of traces to grid lines extension.
+            If 'full', then extends quality grid base points to field borders.
+            If 'cell', then extends quality grid base points to sparce grid cells borders.
+            If False, then make no extension.
+            If int, then extends quality grid base points to +-extension//2 neighboring points.
         filter_outliers : int
             A degree of quality map decimation.
             `filter_outliers` more than zero cuts small complex areas.
@@ -495,9 +499,11 @@ class SeismicGeometry(CacheMixin, ExportMixin):
         """
         from ..metrics import GeometryMetrics #pylint: disable=import-outside-toplevel
 
-        elongation = kwargs.pop('full_lines', elongation) # for old api consistency
+        full_lines = kwargs.pop('full_lines', False) # for old api consistency
+        extension = 'full' if full_lines else extension
+
         quality_grid = GeometryMetrics(self).make_grid(self.quality_map, frequencies, iline=iline, xline=xline,
-                                                       margin=margin, elongation=elongation,
+                                                       margin=margin, extension=extension,
                                                        filter_outliers=filter_outliers, **kwargs)
         self._quality_grid = quality_grid
         return quality_grid

--- a/seismiqb/src/labels/horizon.py
+++ b/seismiqb/src/labels/horizon.py
@@ -655,7 +655,7 @@ class Horizon(AttributesMixin, CacheMixin, CharismaMixin, VisualizationMixin):
         apply_smoothing : bool
             Whether to smooth out the result.
         kwargs : dict
-            Other parameters for grid creation, see `:meth:~.SeismicGeometry.make_grid`.
+            Other parameters for grid creation, see `:meth:~.SeismicGeometry.make_quality_grid`.
         """
         frequencies = frequencies if isinstance(frequencies, (tuple, list)) else [frequencies]
         carcass = copy(self)

--- a/seismiqb/src/metrics.py
+++ b/seismiqb/src/metrics.py
@@ -962,10 +962,8 @@ class GeometryMetrics(BaseMetrics):
 
         return quality_map, plot_dict
 
-    def make_grid(
-        self, quality_map, frequencies, iline=True, xline=True, full_lines=True,
-        margin=0, elongation=0, filter_outliers=0, **kwargs
-    ):
+    def make_grid(self, quality_map, frequencies, iline=True, xline=True, full_lines=True,
+                  margin=0, elongation=0, filter_outliers=0, **kwargs):
         """ Create grid with various frequencies based on quality map. """
         _ = kwargs
         if margin:
@@ -980,10 +978,9 @@ class GeometryMetrics(BaseMetrics):
             quality_map[(bad_traces - self.geometry.zero_traces) == 1] = 0.0
 
         pre_grid = np.rint(quality_map)
-        grid = gridify(
-            pre_grid, frequencies, iline, xline, full_lines,
-            elongation=elongation, filter_outliers=filter_outliers
-        )
+        grid = gridify(matrix=pre_grid, frequencies=frequencies,
+                       iline=iline, xline=xline, full_lines=full_lines,
+                       elongation=elongation, filter_outliers=filter_outliers)
 
         if margin:
             grid[(bad_traces - self.geometry.zero_traces) == 1] = 0

--- a/seismiqb/src/metrics.py
+++ b/seismiqb/src/metrics.py
@@ -962,10 +962,12 @@ class GeometryMetrics(BaseMetrics):
 
         return quality_map, plot_dict
 
-    def make_grid(self, quality_map, frequencies, iline=True, xline=True, full_lines=True,
-                  margin=0, elongation=0, filter_outliers=0, **kwargs):
+    def make_grid(self, quality_map, frequencies, iline=True, xline=True, margin=0,
+                  elongation='full_lines', filter_outliers=0, **kwargs):
         """ Create grid with various frequencies based on quality map. """
+        elongation = kwargs.pop('full_lines', elongation) # for old api consistency
         _ = kwargs
+
         if margin:
             bad_traces = np.copy(self.geometry.zero_traces)
             bad_traces[:, 0] = 1
@@ -978,8 +980,7 @@ class GeometryMetrics(BaseMetrics):
             quality_map[(bad_traces - self.geometry.zero_traces) == 1] = 0.0
 
         pre_grid = np.rint(quality_map)
-        grid = gridify(matrix=pre_grid, frequencies=frequencies,
-                       iline=iline, xline=xline, full_lines=full_lines,
+        grid = gridify(matrix=pre_grid, frequencies=frequencies, iline=iline, xline=xline,
                        elongation=elongation, filter_outliers=filter_outliers)
 
         if margin:

--- a/seismiqb/src/metrics.py
+++ b/seismiqb/src/metrics.py
@@ -963,9 +963,11 @@ class GeometryMetrics(BaseMetrics):
         return quality_map, plot_dict
 
     def make_grid(self, quality_map, frequencies, iline=True, xline=True, margin=0,
-                  elongation='full_lines', filter_outliers=0, **kwargs):
+                  extension='full', filter_outliers=0, **kwargs):
         """ Create grid with various frequencies based on quality map. """
-        elongation = kwargs.pop('full_lines', elongation) # for old api consistency
+        full_lines = kwargs.pop('full_lines', False) # for old api consistency
+        extension = 'full' if full_lines else extension
+
         _ = kwargs
 
         if margin:
@@ -981,7 +983,7 @@ class GeometryMetrics(BaseMetrics):
 
         pre_grid = np.rint(quality_map)
         grid = gridify(matrix=pre_grid, frequencies=frequencies, iline=iline, xline=xline,
-                       elongation=elongation, filter_outliers=filter_outliers)
+                       extension=extension, filter_outliers=filter_outliers)
 
         if margin:
             grid[(bad_traces - self.geometry.zero_traces) == 1] = 0

--- a/seismiqb/src/metrics.py
+++ b/seismiqb/src/metrics.py
@@ -959,9 +959,13 @@ class GeometryMetrics(BaseMetrics):
             'zmin': 0.0, 'zmax': np.nanmax(quality_map),
             **kwargs
         }
+
         return quality_map, plot_dict
 
-    def make_grid(self, quality_map, frequencies, iline=True, xline=True, full_lines=True, margin=0, **kwargs):
+    def make_grid(
+        self, quality_map, frequencies, iline=True, xline=True, full_lines=True,
+        margin=0, elongation=0, filter_outliers=0, **kwargs
+    ):
         """ Create grid with various frequencies based on quality map. """
         _ = kwargs
         if margin:
@@ -976,7 +980,10 @@ class GeometryMetrics(BaseMetrics):
             quality_map[(bad_traces - self.geometry.zero_traces) == 1] = 0.0
 
         pre_grid = np.rint(quality_map)
-        grid = gridify(pre_grid, frequencies, iline, xline, full_lines)
+        grid = gridify(
+            pre_grid, frequencies, iline, xline, full_lines,
+            elongation=elongation, filter_outliers=filter_outliers
+        )
 
         if margin:
             grid[(bad_traces - self.geometry.zero_traces) == 1] = 0

--- a/seismiqb/src/metrics.py
+++ b/seismiqb/src/metrics.py
@@ -963,7 +963,7 @@ class GeometryMetrics(BaseMetrics):
         return quality_map, plot_dict
 
     def make_grid(self, quality_map, frequencies, iline=True, xline=True, margin=0,
-                  extension='full', filter_outliers=0, **kwargs):
+                  extension='cell', filter_outliers=0, **kwargs):
         """ Create grid with various frequencies based on quality map. """
         full_lines = kwargs.pop('full_lines', False) # for old api consistency
         extension = 'full' if full_lines else extension


### PR DESCRIPTION
Add extension for grid lines and filter outliers on the quality map for better quality grid views.

Old view:
![image](https://user-images.githubusercontent.com/21172482/145816812-fe8bb43f-4e44-41e0-a821-0bdd57f5b41f.png)

New view (```extension = 'cell'``` and ```filter_outliers=100```):
![image](https://user-images.githubusercontent.com/21172482/145817617-958d5d8a-8a9a-419e-869c-68f621c6a33a.png)

```filter_outliers``` filter regions with small connectivity objects from the quality map.
![image](https://user-images.githubusercontent.com/21172482/145816310-7f5fb554-6820-4f49-9e35-e14887c4be5b.png)

The ```extension``` parameter extends lines from points on the quality map.

Possible modes: 
 - 'full' for extension to a field borders.
 - 'cell' for extension to a grid cell borders.
 - False - no extension.
 - int number extends to the neighbouring points in range +-number//2.