### PR TITLE
Fix arguments

### DIFF
--- a/seismiqb/crop_batch.py
+++ b/seismiqb/crop_batch.py
@@ -373,7 +373,7 @@ class SeismicCropBatch(Batch):
     # Loading of labels
     @action
     @inbatch_parallel(init='indices', post='_assemble', target='for')
-    def create_masks(self, ix, dst, indices='all', width=3, src_labels='labels', sparse=False):
+    def create_masks(self, ix, dst, indices='all', width=3, src_labels='labels'):
         """ Create masks from labels in stored `locations`.
 
         Parameters
@@ -389,12 +389,10 @@ class SeismicCropBatch(Batch):
             Width of the resulting label.
         src_labels : str
             Dataset attribute with labels dict.
-        sparse : bool
-            Create mask only for labeled slices (for Faults). Unlabeled slices will be marked by -1.
         """
         field = self.get(ix, 'fields')
         location = self.get(ix, 'locations')
-        return field.make_mask(location=location, width=width, indices=indices, src=src_labels, sparse=sparse)
+        return field.make_mask(location=location, width=width, indices=indices, src=src_labels)
 
 
     @action

--- a/seismiqb/field/synthetic.py
+++ b/seismiqb/field/synthetic.py
@@ -139,10 +139,10 @@ class SyntheticField:
              )
 
             # Faults
-            for fault_params in params['make_fault_2d']:
+            for fault_params in params.get('make_fault_2d', []):
                 generator.make_fault_2d(**fault_params)
 
-            for fault_params in params['make_fault_3d']:
+            for fault_params in params.get('make_fault_3d', []):
                 generator.make_fault_3d(**fault_params)
 
             # Finalize synthetic creation
@@ -198,7 +198,13 @@ class SyntheticField:
 
         # Labels: horizons and faults
         elif 'horizon' in attribute:
-            result = generator.get_horizons(indices='all', format='mask', width=kwargs.get('width', 3))
+            kwargs = {
+                'indices': 'all',
+                'width': 3,
+                'format': 'mask',
+                **kwargs
+            }
+            result = generator.get_horizons(**kwargs)
         elif 'amplified' in attribute:
             result = generator.get_horizons(indices='amplified', format='mask', width=kwargs.get('width', 3))
         elif 'fault' in attribute:

--- a/seismiqb/geometry/base.py
+++ b/seismiqb/geometry/base.py
@@ -815,12 +815,22 @@ class SeismicGeometry(CacheMixin, ExportMixin):
 
     def show_quality_map(self, **kwargs):
         """ Show quality map. """
-        self.show(matrix=self.quality_map, cmap='Reds', title=f'Quality map of `{self.displayed_name}`')
+        plot_params = {
+            'cmap': 'Reds',
+            'title': f'Quality map of `{self.displayed_name}`',
+            **kwargs
+        }
+        self.show(matrix=self.quality_map, **plot_params)
 
     def show_quality_grid(self, **kwargs):
         """ Show quality grid. """
-        self.show(matrix=self.quality_grid, cmap='Reds', interpolation='bilinear',
-                  title=f'Quality grid of `{self.displayed_name}`')
+        plot_params = {
+            'cmap': 'Reds',
+            'interpolation': 'bilinear',
+            'title': f'Quality grid of `{self.displayed_name}`',
+            **kwargs
+        }
+        self.show(matrix=self.quality_grid, **plot_params)
 
 
     # Coordinate conversion


### PR DESCRIPTION
1. Remove unused`sparse` arg from `SeismicCropBatch.create_masks`.
2. Make faults params optional in `SyntheticField._populate_generator`.
3. Allow `indices` in `SyntheticField.get_attribute`.