### PR TITLE
Refactor cache

### DIFF
--- a/seismiqb/field/base.py
+++ b/seismiqb/field/base.py
@@ -452,11 +452,11 @@ class Field(CharismaMixin, VisualizationMixin):
         self.attached_instances.reset_cache()
 
     @property
-    def cache_size(self):
-        """ Total size of cached data. """
-        size = self.geometry.cache_size
-        size += sum(self.attached_instances.cache_size)
-        return size
+    def cache_nbytes(self):
+        """ Total nbytes of cached data. """
+        nbytes = self.geometry.cache_nbytes
+        nbytes += sum(self.attached_instances.cache_nbytes)
+        return nbytes
 
     # Facies
     def evaluate_facies(self, src_horizons, src_true=None, src_pred=None, metrics='dice'):

--- a/seismiqb/labels/horizon/attributes.py
+++ b/seismiqb/labels/horizon/attributes.py
@@ -16,7 +16,6 @@ from sklearn.decomposition import PCA
 
 from ...functional import hilbert
 from ...utils import transformable, lru_cache
-from ...utils.cache import cached_property
 
 
 
@@ -183,12 +182,14 @@ class AttributesMixin:
         """ A method for getting matrix in cubic coordinates. Allows for introspectable cache. """
         return self.matrix_put_on_full(self.matrix)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=1, apply_by_default=True, copy_on_return=True)
     def binary_matrix(self):
         """ Boolean matrix with `True` values at places where horizon is present and `False` everywhere else. """
         return (self.matrix != self.FILL_VALUE).astype(np.bool)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=1, apply_by_default=True, copy_on_return=True)
     def full_binary_matrix(self):
         """ A method for getting binary matrix in cubic coordinates. Allows for introspectable cache. """
         return self.matrix_put_on_full(self.binary_matrix)

--- a/seismiqb/labels/horizon/attributes.py
+++ b/seismiqb/labels/horizon/attributes.py
@@ -197,7 +197,8 @@ class AttributesMixin:
         """ An alias. """
         return self.full_binary_matrix
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=1, apply_by_default=True, copy_on_return=True)
     def float_matrix(self):
         """ Matrix with smoothed float values in cubic (ordinal) coordinates. """
         if self.dtype == np.float32:

--- a/seismiqb/labels/horizon/attributes.py
+++ b/seismiqb/labels/horizon/attributes.py
@@ -1,7 +1,7 @@
 """ Mixin with computed along horizon geological attributes. """
 # pylint: disable=too-many-statements
 from copy import copy
-from functools import cached_property, wraps
+from functools import wraps
 
 from math import isnan
 import numpy as np
@@ -16,6 +16,7 @@ from sklearn.decomposition import PCA
 
 from ...functional import hilbert
 from ...utils import transformable, lru_cache
+from ...utils.cache import cached_property
 
 
 

--- a/seismiqb/utils/cache.py
+++ b/seismiqb/utils/cache.py
@@ -211,11 +211,7 @@ class lru_cache:
             # Init cache and reference on it in the GlobalCache controller
             if not hasattr(instance, 'cache'):
                 # Init cache container in the instance
-                instance.__setattr__('cache', {})
-
-            if self.attrname not in instance.cache:
-                # Init property/method cache in the cache container
-                instance.cache[self.attrname] = OrderedDict()
+                instance.__setattr__('cache', defaultdict(OrderedDict))
 
             GlobalCache.instances_with_cache.add(instance)
 
@@ -307,7 +303,7 @@ class CacheMixin:
             names = (name,) if name is not None else self.cache.keys()
 
             for attrname in names:
-                cached_values = self.cache.get(attrname, {}).values()
+                cached_values = self.cache[attrname].values()
 
                 cache_length_accumulator += len(cached_values)
 
@@ -328,7 +324,7 @@ class CacheMixin:
             names = (name,) if name is not None else self.cache.keys()
 
             for attrname in names:
-                cached_values = self.cache.get(attrname, {}).values()
+                cached_values = self.cache[attrname].values()
 
                 for value in cached_values:
                     if isinstance(value, np.ndarray):

--- a/seismiqb/utils/cache.py
+++ b/seismiqb/utils/cache.py
@@ -17,6 +17,7 @@ def cached_property(func):
 
     For more, read the :class:`functools.cached_property` docstring.
     """
+    # pylint: disable=protected-access 
     CacheMixin._global_cache_container['properties'].add(func.__name__)
     return functools_cached_property(func)
 
@@ -201,8 +202,8 @@ class CacheMixin:
     def cached_objects(self):
         """ All properties and methods names that use caching. """
         if getattr(self, '_cached_objects', None) is None:
-            cached_properties = [obj for obj in self._global_cache_container['properties'] if obj in dir(self)]
-            cached_methods = [obj for obj in self._global_cache_container['methods'] if obj in dir(self)]
+            cached_properties = [obj for obj in self._global_cache_container['properties'] if hasattr(self, obj)]
+            cached_methods = [obj for obj in self._global_cache_container['methods'] if hasattr(self, obj)]
 
             self._cached_objects = {'properties': set(cached_properties),
                                     'methods': set(cached_methods)}

--- a/seismiqb/utils/cache.py
+++ b/seismiqb/utils/cache.py
@@ -168,6 +168,7 @@ class lru_cache:
 
     def make_key(self, instance, func, args, kwargs):
         """ Create a key from a combination of method args and instance attributes. """
+        # pylint: disable=unsupported-membership-test
         # We get names and values for args and defaults from the func signature
         if self.func_signature is None:
             self.func_signature = signature(func).parameters

--- a/seismiqb/utils/cache.py
+++ b/seismiqb/utils/cache.py
@@ -19,6 +19,7 @@ class _GlobalCacheClass:
     Note, this class controls only objects which use :class:`~.lru_cache`.
     So, for properties you need to use both `property` and `lru_cache` decorators for proper cache introspection.
     """
+    #pylint: disable=redefined-builtin
     def __init__(self):
         """ Initialize containers with cache references and instances with cached objects.
 
@@ -115,7 +116,6 @@ class _GlobalCacheClass:
         format : {'dict', 'df'}
             Return value format. 'df' means pandas DataFrame.
         """
-        #pylint: disable=redefined-builtin
         cache_repr_ = {}
 
         # Extract cache repr for each cached object

--- a/seismiqb/utils/cache.py
+++ b/seismiqb/utils/cache.py
@@ -2,7 +2,6 @@
 import os
 from copy import copy
 from functools import wraps
-from hashlib import blake2b
 from inspect import ismethod, signature
 import json
 from threading import RLock

--- a/seismiqb/utils/cache.py
+++ b/seismiqb/utils/cache.py
@@ -291,6 +291,7 @@ class CacheMixin:
     @property
     def cached_objects(self):
         """ All object names that use caching. """
+        # pylint: disable=protected-access
         if not hasattr(self.__class__, '_cached_objects'):
             class_dir = dir(self.__class__)
             cached_objects = [obj_qualname for obj_qualname in GlobalCache.cache_references.keys()


### PR DESCRIPTION
For a big amount of horizons `CacheMixin.get_cached_objects` (in cache reset) call took a long time because of iterating on `horizon.__dir__()` objects.
Cache logic was changed: now all cache stored in the object (in the `cache` attribute).
New implementation controls only methods and properties which use `lru_cache` decorator from the **seismiqb**.

Also, add the `GlobalCache` object for global cache introspection and cleaning.
`GlobalCache` implemented through weak references, so it is properly works with deleted elements.