### PR TITLE
Fix cache bug

### DIFF
--- a/seismiqb/field/base.py
+++ b/seismiqb/field/base.py
@@ -454,7 +454,9 @@ class Field(CharismaMixin, VisualizationMixin):
     def cache_nbytes(self):
         """ Total nbytes of cached data. """
         nbytes = self.geometry.cache_nbytes
-        nbytes += sum(self.attached_instances.cache_nbytes)
+
+        if len(self.attached_instances) > 0:
+            nbytes += sum(self.attached_instances.cache_nbytes)
         return nbytes
 
     # Facies


### PR DESCRIPTION
There was an error when `field.attached_instances` is an empty AugmentedList: `cache_nbytes` was failed.