### PR TITLE
Refactor `labels` argument in the `Field`

### DIFF
--- a/seismiqb/dataset.py
+++ b/seismiqb/dataset.py
@@ -32,7 +32,7 @@ class SeismicDataset(Dataset):
     Named arguments are passed for each field initialization.
     """
     #pylint: disable=keyword-arg-before-vararg
-    def __init__(self, index, batch_class=SeismicCropBatch, *args, **kwargs):
+    def __init__(self, index, batch_class=SeismicCropBatch, *args, **geometry_kwargs):
         if args:
             raise TypeError('Positional args are not allowed for `SeismicDataset` initialization!')
 
@@ -48,9 +48,9 @@ class SeismicDataset(Dataset):
                 if isinstance(field_idx, (Field, SyntheticField)):
                     field = field_idx
                     if labels_idx is not None:
-                        field.load_labels(labels=labels_idx, **kwargs)
+                        field.load_labels(labels=labels_idx)
                 else:
-                    field = Field(geometry=field_idx, labels=labels_idx, **kwargs)
+                    field = Field(geometry=field_idx, labels=labels_idx, **geometry_kwargs)
 
                 self.fields[field.short_name] = field
         else:


### PR DESCRIPTION
Arguments `labels_class` and `labels_kwargs` moved into `labels` argument.

Now, if you want to provide `label_class` you should use dictionary sructure for labels.
For example, instead of:

```python
dataset = SeismicDataset({cube_path : horizon_path}, labels_class='horizon')
```

you should use one of:

```python
dataset = SeismicDataset({cube_path : {'labels': {'src': horizon_path, 'class':'horizon'}}})
dataset = SeismicDataset({cube_path : {'horizon': {'src': horizon_path}}})
```

TODO:

- [ ] Rewrite docs
- [ ] Fix dependencies (tests fails because they are not rewritten in the new way)


----
Other most common-used examples:

## Example 1

```python
# Old-fashioned code
index = {'/data/seismic_data/seismic_interpretation/002_M/002_M.sgy':
         '~/INPUTS/HORIZONS/FINAL/*'}

dataset = SeismicDataset(index=index, labels_class='horizon')

# New option
index = {'/data/seismic_data/seismic_interpretation/002_M/002_M.sgy':
         {'horizon': '~/INPUTS/HORIZONS/FINAL/*'}}

dataset = SeismicDataset(index=index)

# or
index = {'/data/seismic_data/seismic_interpretation/002_M/002_M.sgy':
         {'custom_name': {'src':'~/INPUTS/HORIZONS/FINAL/*', 'class':'horizon'} } }

dataset = SeismicDataset(index=index)
```


## Example 2

```python
# Old-fashioned code
field.load_labels(labels=horizons_labels_path, labels_class='horizon')

# New options
field.load_labels(labels={'custom_name': {'src': horizons_labels_path, 'class': 'horizon'}}) # provide class directly
field.load_labels(labels={'horizon': {'src': horizons_labels_path}}) # provide class through name
field.load_labels(labels={'horizon': horizons_labels_path}) # the same as previous, but shorter
```

## Example 3

```python
# Data
sticks1 = np.array([
    [[100, 100, 25],
     [100, 130, 175]],
    [[120, 100, 25],
     [120, 130, 175]],
    [[140, 100, 25],
     [140, 130, 175]]
])

sticks2 = sticks1 + 30

# Old-fashioned code
dataset = SeismicDataset({field: [{'sticks': s} for s in [sticks1, sticks2]]}, labels_class=Fault)

# New option
labels = {'custom_name': {'src': [{'sticks': s} for s in [sticks1, sticks2]], 'class': Fault}}
dataset = SeismicDataset({field: labels})

# or
labels = {'fault': {'src': [{'sticks': s} for s in [sticks1, sticks2]]}}
dataset = SeismicDataset({field: labels})
```
