### PR TITLE
Replace `np.take` with basic indexing in `get_crop_mask`

### DIFF
--- a/seismiqb/geometry/base.py
+++ b/seismiqb/geometry/base.py
@@ -15,7 +15,7 @@ from .conversion_mixin import ConversionMixin
 from .export_mixin import ExportMixin
 from .metric_mixin import MetricMixin
 
-from ..utils import SQBStorage, lru_cache, CacheMixin, TransformsMixin, select_printer, transformable
+from ..utils import SQBStorage, lru_cache, CacheMixin, TransformsMixin, select_printer, transformable, take_along_axis
 from ..plotters import plot
 
 
@@ -948,7 +948,7 @@ class Geometry(BenchmarkMixin, CacheMixin, ConversionMixin, ExportMixin, MetricM
         axis : int
             Axis of the slide.
         """
-        dead_traces = np.take(self.dead_traces_matrix, indices=index, axis=axis)
+        dead_traces = take_along_axis(self.dead_traces_matrix, index=index, axis=axis)
         left_bound = np.argmin(dead_traces)
         right_bound = len(dead_traces) - np.argmin(dead_traces[::-1]) # the first dead trace
         return left_bound, right_bound
@@ -1059,12 +1059,7 @@ class Geometry(BenchmarkMixin, CacheMixin, ConversionMixin, ExportMixin, MetricM
         dilation_kernel = np.ones((dilation, dilation), dtype=array.dtype)
 
         for i in range(array.shape[axis]):
-            if axis == 0:
-                slide = array[i, ...]
-            elif axis == 1:
-                slide = array[:, i, :]
-            else:
-                raise ValueError('axis should be either 0 (iline) or 1 (xline)')
+            slide = take_along_axis(array, i, axis)
             ptps = cv2.dilate(slide, ptp_kernel) - cv2.erode(slide, ptp_kernel)
             mask_ = ptps <= threshold
             if erosion:

--- a/seismiqb/geometry/base.py
+++ b/seismiqb/geometry/base.py
@@ -1059,7 +1059,12 @@ class Geometry(BenchmarkMixin, CacheMixin, ConversionMixin, ExportMixin, MetricM
         dilation_kernel = np.ones((dilation, dilation), dtype=array.dtype)
 
         for i in range(array.shape[axis]):
-            slide = array.take(i, axis=axis)
+            if axis == 0:
+                slide = array[i, ...]
+            elif axis == 1:
+                slide = array[:, i, :]
+            else:
+                raise ValueError('axis should be either 0 (iline) or 1 (xline)')
             ptps = cv2.dilate(slide, ptp_kernel) - cv2.erode(slide, ptp_kernel)
             mask_ = ptps <= threshold
             if erosion:

--- a/seismiqb/labels/fault/base.py
+++ b/seismiqb/labels/fault/base.py
@@ -8,7 +8,7 @@ from .triangulation import sticks_to_simplices, triangle_rasterization
 from .approximation import points_to_sticks
 from .visualization import FaultVisualizationMixin, get_fake_one_stick_fault
 from .formats import FaultSticksMixin, FaultSerializationMixin
-from ...utils import insert_points_into_mask
+from ...utils import insert_points_into_mask, take_along_axis
 
 class Fault(FaultSticksMixin, FaultSerializationMixin, FaultVisualizationMixin):
     """ Class to represent Fault object.
@@ -349,7 +349,7 @@ class Fault(FaultSticksMixin, FaultSerializationMixin, FaultVisualizationMixin):
 
             points = points[np.isin(points[:, self.direction], loc)]
 
-            unlabeled_slides = np.take(mask, loc - mask_bbox[self.direction, 0], self.direction)
+            unlabeled_slides = take_along_axis(mask, loc - mask_bbox[self.direction, 0], self.direction)
             unlabeled_slides = loc[unlabeled_slides[:, 0, 0] == -1]
 
             slices = [slice(None)] * 3

--- a/seismiqb/nn/utils.py
+++ b/seismiqb/nn/utils.py
@@ -11,7 +11,7 @@ from batchflow import Pipeline, B
 from batchflow.models.torch import TorchModel
 
 from .. import SeismicDataset, RegularGrid
-from ..utils import Accumulator3D
+from ..utils import Accumulator3D, take_along_axis
 
 
 def make_slide_prediction(field, model_or_path, index, axis=0,
@@ -97,7 +97,7 @@ def make_slide_prediction(field, model_or_path, index, axis=0,
             trace = prediction[i, x, :]
             peaks, _ = find_peaks(trace, prominence=0.15, width=2)
             peaked[i, x, peaks] = 1
-    prediction = np.take(peaked, indices=inference_width, axis=axis)
+    prediction = take_along_axis(peaked, index=inference_width, axis=axis)
 
     # Filter small objects
     labeled = label(prediction, connectivity=2)

--- a/seismiqb/utils/accumulator3d.py
+++ b/seismiqb/utils/accumulator3d.py
@@ -13,7 +13,7 @@ from sklearn.linear_model import LinearRegression
 
 from batchflow import Notifier
 
-from .functions import generate_string, triangular_weights_function_nd
+from .functions import generate_string, triangular_weights_function_nd, take_along_axis
 
 
 
@@ -306,7 +306,7 @@ class Accumulator3D:
                                                     **dataset_kwargs_)
 
                     for i in range(data.shape[axis]):
-                        projection[i] = transform(np.take(data, i, axis=axis))
+                        projection[i] = transform(take_along_axis(data, i, axis=axis))
                         progress_bar.update()
         return h5py.File(path, mode='r')
 

--- a/seismiqb/utils/functions.py
+++ b/seismiqb/utils/functions.py
@@ -274,9 +274,13 @@ def insert_points_into_mask(mask, points, mask_bbox, width, axis, alpha=1):
 
 
 def take_along_axis(array, index, axis):
-    """ As np.take but creates view of array guaranteed """
+    """ A functional equivalent of `np.take` which returns a view.
+    Unlike `np.take`, should be used only with indices that are ints or slice.
+    """
     if axis == 0:
-        slide = array[index, :]
+        slide = array[index, :, :]
     elif axis == 1:
-        slide = array[:, index]
+        slide = array[:, index, :]
+    elif axis == 2:
+        slide = array[:, :, index]
     return slide

--- a/seismiqb/utils/functions.py
+++ b/seismiqb/utils/functions.py
@@ -271,3 +271,12 @@ def insert_points_into_mask(mask, points, mask_bbox, width, axis, alpha=1):
             elif axis == 2:
                 for pos in range(left_bound, right_bound):
                     mask[point[0], point[1], pos] = alpha
+
+
+def take_along_axis(array, index, axis):
+    """ As np.take but creates view of array guaranteed """
+    if axis == 0:
+        slide = array[index, :]
+    elif axis == 1:
+        slide = array[:, index]
+    return slide


### PR DESCRIPTION
`np.take` works too long on subcubes of the original cube. 
For example:

![image](https://github.com/gazprom-neft/seismiqb/assets/106237959/a8ef6ea5-8b50-46ad-98a4-c765bb06e49d)

